### PR TITLE
fix(filemanager): fix bug with fileManager controller when uploading …

### DIFF
--- a/controllers/fileManager.controller.js
+++ b/controllers/fileManager.controller.js
@@ -755,9 +755,11 @@ export const Upload = (req, res) => {
     const fileName = req.files.map(file => file.originalname);
     const filePath = path.join(contentRootPath, req.body.path);
     for (let i = 0; i < fileName.length; i++) {
-      fs.rename('./' + fileName[i], path.join(filePath, fileName[i]), function (err) {
-        if (err) throw err;
-      });
+      // fs.rename('./' + fileName[i], path.join(filePath, fileName[i]), function (err) {
+      //   if (err) throw err;
+      // });
+      fs.copyFileSync('./' + fileName[i], path.join(filePath, fileName[i]));
+      fs.unlinkSync('./' + fileName[i]);
     }
     res.send('Success');
   }


### PR DESCRIPTION
…files

bug was with fs.rename when moving files from tmp dir into user dir; rename does not work across different mount points see EXDEV on https://man7.org/linux/man-pages/man2/rename.2.html